### PR TITLE
#165164918  Fix typo when a user signs up  with a short password

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -22,7 +22,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
             code='invalid_password')],
 
         error_messages={
-            'min_length': 'Password should be at least 8 characters longclear',
+            'min_length': 'Password should be at least 8 characters long',
             'max_length': 'Password should not be longer than 128 characters',
             'blank': 'Password cannot be blank',
             'required': 'Password is required'


### PR DESCRIPTION
 __What does this PR do?__
Fixes a typo on the error message that a user gets when they sign up with a short password.

__Description of tasks to be completed__
-  Replace the word `longclear` with `long.`

__How should this be manually tested__
-  Clone the repo.
-   Create a virtual environment and activate it using the commands below.
       - `virtualenv venv`
       - `source venv/bin/actuvate`

- Install all the projects requirements using the command below.
     - `pip install -r requirements.txt`
- Run the local server
   -  `python manage.py runserver`

- test the endpoint on postman by navigating to `http://127.0.0.1:8000/api/users/` and adding the payload below on the body section of postman then hit send
   
```
                 {
	"user":{
		"email":"example@gmail.com",
		"password":"short",
		"username":"tesuser"
	}
}
```

- you should expect to get an error message below

```
{
    "errors": {
        "password": [
            "Password should be at least 8 characters long"
        ]
    }
}
```
      
