### PR TITLE
#166181817 Bug fix enabling a user to access the entire profile payload on avatar update

### DIFF
--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -176,7 +176,9 @@ class AvatarView(APIView):
                 serializer.save()
                 return Response(
                     {
-                        "success": "Your profile avatar has been updated successfully"
+                        "success": "Avatar updated successfully",
+                        "profile": serializer.data
+
                     }, status=200)
         except Exception as e:
             APIException.status_code = status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
#### What does this PR do?
* It enables access of entire profile payload on updating the avatar as opposed to just the success message.

#### Description of the task to be completed 
* Enable users of the API to access the profile payload on accessing the update avatar url endpoint

#### PT story
https://www.pivotaltracker.com/story/show/166181817