### PR TITLE
#166207237 - Remove unnecessary signup calls

### DIFF
--- a/authors/apps/articles/tests/commons.py
+++ b/authors/apps/articles/tests/commons.py
@@ -20,38 +20,20 @@ class BaseSetup(TestCase):
         self.client = APIClient()
         self.client2 = APIClient()
         self.client3 = APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='demo@mail.com',
+            username='Bob',
+            password='Bob12345'
         )
-        self.user2 = self.client2.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "pete@mail.com",
-                    "username": "Pete",
-                    "password": "Pete12345"
-                }
-            },
-            format="json"
+        self.user2 = User.objects.create_user(
+            email='pete@mail.com',
+            username='Pete',
+            password='Pete12345'
         )
-        self.user3 = self.client3.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "jane@mail.com",
-                    "username": "Jane",
-                    "password": "Jane12345"
-                }
-            },
-            format="json"
+        self.user2 = User.objects.create_user(
+            email='jane@mail.com',
+            username='Jane',
+            password='Jane12345'
         )
         test_user = User.objects.get(username="Bob")
         test_user.is_verified = True

--- a/authors/apps/articles/tests/test_article_images.py
+++ b/authors/apps/articles/tests/test_article_images.py
@@ -12,16 +12,10 @@ from authors.apps.authentication.models import User
 class TestArticle(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "Test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test@mail.com',
+            username='Test',
+            password='test1234'
         )
 
         # verify email
@@ -54,6 +48,29 @@ class TestArticle(TestCase):
             },
             format="json"
         )
+        self.client_3 = test.APIClient()
+        self.user_3 = User.objects.create_user(
+            email='test3@mail.com',
+            username='Test3',
+            password='test1234'
+        )
+
+        test_user_3 = User.objects.get(username='Test3')
+        test_user_3.is_verified = True
+        test_user_3.save()
+        self.login_3 = self.client_3.post(
+            reverse('authentication:user-login'),
+            data={
+                "user": {
+                    "email": "test3@mail.com",
+                    "password": "test1234"
+                }
+            },
+            format="json"
+        )
+
+        self.client_3.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.login_3.data['token'])
 
     @property
     def temporary_image(self):
@@ -182,37 +199,6 @@ class TestArticle(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_upload_not_authorized(self):
-
-        self.client_3 = test.APIClient()
-        self.user_3 = self.client_3.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test3@mail.com",
-                    "username": "Test3",
-                    "password": "test1234"
-                }
-            },
-            format="json"
-        )
-
-        test_user_3 = User.objects.get(username='Test3')
-        test_user_3.is_verified = True
-        test_user_3.save()
-        self.login_3 = self.client_3.post(
-            reverse('authentication:user-login'),
-            data={
-                "user": {
-                    "email": "test3@mail.com",
-                    "password": "test1234"
-                }
-            },
-            format="json"
-        )
-
-        self.client_3.credentials(
-            HTTP_AUTHORIZATION='Bearer ' + self.login_3.data['token'])
-
         response = self.client_3.post(
             reverse(
                 'articles:add-image',
@@ -228,37 +214,6 @@ class TestArticle(TestCase):
                          'Only the owner of this article can upload images.')
 
     def test_delete_not_authorized(self):
-
-        self.client_3 = test.APIClient()
-        self.user_3 = self.client_3.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test3@mail.com",
-                    "username": "Test3",
-                    "password": "test1234"
-                }
-            },
-            format="json"
-        )
-
-        test_user_3 = User.objects.get(username='Test3')
-        test_user_3.is_verified = True
-        test_user_3.save()
-        self.login_3 = self.client_3.post(
-            reverse('authentication:user-login'),
-            data={
-                "user": {
-                    "email": "test3@mail.com",
-                    "password": "test1234"
-                }
-            },
-            format="json"
-        )
-
-        self.client_3.credentials(
-            HTTP_AUTHORIZATION='Bearer ' + self.login_3.data['token'])
-
         self.client.post(
             reverse('articles:add-image',
                     kwargs={

--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -12,16 +12,10 @@ from authors.apps.articles.filters import ArticleFilter
 class TestArticle(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "Test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test@mail.com',
+            username='Test',
+            password='test1234'
         )
 
         # verify email
@@ -112,7 +106,7 @@ class TestArticle(TestCase):
             data={
                 "article": {
                     "title": "the house in the hill",
-                    "body": "the hill was grassy with a single house at the apex",
+                    "body": "the hill was grassy with a single house apex",
                     "description": "a hill story",
                     "tags": "0"
                 }
@@ -294,16 +288,10 @@ class TestArticle(TestCase):
         )
 
         self.client_2 = test.APIClient()
-        self.user_2 = self.client_2.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test2@mail.com",
-                    "username": "Test2",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user_2 = User.objects.create_user(
+            username='Test2',
+            email='test2@mail.com',
+            password='test1234',
         )
 
         test_user_2 = User.objects.get(username='Test2')
@@ -340,7 +328,10 @@ class TestArticle(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data['message'], 'Only the owner can edit this article.')
+        self.assertEqual(
+            response.data['message'],
+            'Only the owner can edit this article.'
+        )
 
     # END OF UPDATE TESTS
 
@@ -425,16 +416,10 @@ class TestArticle(TestCase):
         )
 
         self.client_3 = test.APIClient()
-        self.user_3 = self.client_3.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test3@mail.com",
-                    "username": "Test3",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test3@mail.com',
+            username='Test3',
+            password='test1234'
         )
 
         test_user_3 = User.objects.get(username='Test3')
@@ -465,7 +450,10 @@ class TestArticle(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data['message'], 'Only the owner can delete this article.')
+        self.assertEqual(
+            response.data['message'],
+            'Only the owner can delete this article.'
+        )
 
     # END OF DELETE TESTS
     @property
@@ -553,11 +541,17 @@ class TestArticle(TestCase):
         self.assertRaises(Exception)
 
     def test_user_can_search_articles(self):
-        response = self.client.get("/api/articles/?search=raywire", format="json")
+        response = self.client.get(
+            "/api/articles/?search=raywire",
+            format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_user_can_search_articles_by_tags(self):
-        response = self.client.get("/api/articles/?search=religion,nature", format="json")
+        response = self.client.get(
+            "/api/articles/?search=religion,nature",
+            format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_user_can_filter_articles_by_title(self):
@@ -572,8 +566,11 @@ class TestArticle(TestCase):
                 }
             },
             format="json"
-        )        
-        response = self.client.get("/api/articles/?title=Test title", format="json")
+        )
+        response = self.client.get(
+            "/api/articles/?title=Test title",
+            format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['articles'])
 

--- a/authors/apps/articles/tests/test_favorite.py
+++ b/authors/apps/articles/tests/test_favorite.py
@@ -5,20 +5,13 @@ from rest_framework import test, status
 from authors.apps.articles.models import FavoriteModel, Article
 
 
-
 class FavoriteTestCase(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "Test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test@mail.com',
+            username='Test',
+            password='test1234'
         )
 
         # verify email
@@ -149,8 +142,10 @@ class FavoriteTestCase(TestCase):
             format='json'
         )
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(res.data['message'],
-                         "The article requested does not exist in your favorites")
+        self.assertEqual(
+            res.data['message'],
+            "The article requested does not exist in your favorites"
+        )
 
     def test_user_cannot_remove_from_favorite_if_not_exists(self):
         res = self.client.delete(

--- a/authors/apps/articles/tests/test_highlight.py
+++ b/authors/apps/articles/tests/test_highlight.py
@@ -9,16 +9,10 @@ from authors.apps.articles.filters import ArticleFilter
 class TestArticle(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "Test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test@mail.com',
+            username='Test',
+            password='test1234'
         )
 
         # verify email

--- a/authors/apps/articles/tests/test_like_dislike_articles.py
+++ b/authors/apps/articles/tests/test_like_dislike_articles.py
@@ -2,44 +2,32 @@ import json
 from django.urls import reverse
 from django.test import TestCase
 from rest_framework import test, status
-
 from authors.apps.authentication.models import User
+
 
 class TestLikeArticles(TestCase):
     """
-    this class houses test instances for like/dislike functionality 
+    this class houses test instances for like/dislike functionality
     """
     def setUp(self):
         """
-        this set ups the test class 
+        this set ups the test class
         """
         self.client = test.APIClient()
         self.client2 = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "tworivers@gmail.com",
-                    "username": "disliker",
-                    "password": "usergeneration0"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='tworivers@gmail.com',
+            username='disliker',
+            password='usergeneration0'
         )
 
         verified_user = User.objects.get(username='disliker')
         verified_user.is_verified = True
         verified_user.save()
-        self.user2 = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "tworivers2@gmail.com",
-                    "username": "disliker2",
-                    "password": "usergeneration0"
-                }
-            },
-            format="json"
+        self.user2 = User.objects.create_user(
+            email='tworivers2@gmail.com',
+            username='disliker2',
+            password='usergeneration0'
         )
         verified_user2 = User.objects.get(username='disliker2')
         verified_user2.is_verified = True
@@ -102,8 +90,10 @@ class TestLikeArticles(TestCase):
     def test_like_article(self):
         """Test whether authenticated user can like article"""
         response = self.client.post(
-            reverse('articles:like-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:like-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         output = json.loads(response.content)
@@ -111,17 +101,21 @@ class TestLikeArticles(TestCase):
             'you liked the article:',
             str(output))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    
+
     def test_revoking_like(self):
         """Test whether authenticated user can revoke an article like"""
         self.client.post(
-            reverse('articles:like-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:like-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         response = self.client.post(
-            reverse('articles:like-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:like-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         output = json.loads(response.content)
@@ -133,8 +127,10 @@ class TestLikeArticles(TestCase):
     def test_dislike_article(self):
         """Test whether authenticated user can dislike article"""
         response = self.client.post(
-            reverse('articles:dislike-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:dislike-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         output = json.loads(response.content)
@@ -142,17 +138,21 @@ class TestLikeArticles(TestCase):
             'you disliked the article:',
             str(output))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    
+
     def test_revoking_dislike(self):
         """Test whether authenticated user can revoke an article dislike"""
         self.client.post(
-            reverse('articles:dislike-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:dislike-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         response = self.client.post(
-            reverse('articles:dislike-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:dislike-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         output = json.loads(response.content)
@@ -164,8 +164,10 @@ class TestLikeArticles(TestCase):
     def test_liking_non_existent_article(self):
         """Test whether user can like an article that doesn't exist"""
         response = self.client.post(
-            reverse('articles:like-article',
-            kwargs={'slug': 'the_people_eater'}),
+            reverse(
+                'articles:like-article',
+                kwargs={'slug': 'the_people_eater'}
+            ),
             format='json'
         )
         output = json.loads(response.content)
@@ -179,13 +181,17 @@ class TestLikeArticles(TestCase):
         Tests whether a user can change a dislike to a like
         """
         self.client.post(
-            reverse('articles:dislike-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:dislike-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         response = self.client.post(
-            reverse('articles:like-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:like-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         output = json.loads(response.content)
@@ -193,19 +199,23 @@ class TestLikeArticles(TestCase):
             'you liked the article:',
             str(output))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    
+
     def test_user_can_dislike_liked_article(self):
         """
         Tests whether a user can change a like to a dislike
         """
         self.client.post(
-            reverse('articles:like-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:like-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         response = self.client.post(
-            reverse('articles:dislike-article',
-            kwargs={'slug': self.slug}),
+            reverse(
+                'articles:dislike-article',
+                kwargs={'slug': self.slug}
+            ),
             format='json'
         )
         output = json.loads(response.content)

--- a/authors/apps/articles/tests/test_pagination.py
+++ b/authors/apps/articles/tests/test_pagination.py
@@ -7,16 +7,10 @@ from authors.apps.authentication.models import User
 class TestArticlePagination(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "Test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test@mail.com',
+            username='Test',
+            password='test1234'
         )
 
         # verify email

--- a/authors/apps/articles/tests/test_reviews.py
+++ b/authors/apps/articles/tests/test_reviews.py
@@ -73,9 +73,12 @@ class ReviewTestCase(BaseSetup):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.post_review()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        response = self.client2.delete(reverse('articles:alter-review', kwargs={
-            "slug": Article.objects.get().slug, 'username': "Pete"
-        }))
+        response = self.client2.delete(reverse(
+            'articles:alter-review',
+            kwargs={
+                "slug": Article.objects.get().slug, 'username': "Pete"
+            }
+        ))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_delete = self.client2.get(
             reverse('articles:review', kwargs={
@@ -132,9 +135,15 @@ class ReviewTestCase(BaseSetup):
 
     def test_user_cant_edit_non_existent_review(self):
         self.test_user_can_delete_review()
-        response = self.client2.delete(reverse('articles:alter-review', kwargs={
-            "slug": Article.objects.get().slug, 'username': User.objects.filter(username="Pete").first()
-        }))
+        response = self.client2.delete(
+            reverse(
+                'articles:alter-review',
+                kwargs={
+                    "slug": Article.objects.get().slug,
+                    'username': User.objects.filter(username="Pete").first()
+                }
+            )
+        )
         self.assertEqual(response.status_code,
                          status.HTTP_404_NOT_FOUND)
         self.assertRaises(Exception)
@@ -179,7 +188,10 @@ class ReviewTestCase(BaseSetup):
         response = self.post_review()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_duplicate = self.post_review()
-        self.assertEqual(response_duplicate.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response_duplicate.status_code,
+            status.HTTP_403_FORBIDDEN
+        )
 
     def test_user_cant_get_inexistent_review(self):
         response = self.post_article()
@@ -200,13 +212,17 @@ class ReviewTestCase(BaseSetup):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response2 = self.post_review2()
         self.assertEqual(response2.status_code, status.HTTP_201_CREATED)
-        edit_response = self.client2.put(reverse('articles:alter-review', kwargs={
-            "slug": Article.objects.get().slug, 'username': "Jane"
-        }), data={
-            "review": {
-                "review_body": "I did not liked the article",
-                "rating_value": 3
-            }
-        },
+        edit_response = self.client2.put(
+            reverse(
+                'articles:alter-review',
+                kwargs={
+                    "slug": Article.objects.get().slug,
+                    'username': "Jane"
+                }), data={
+                "review": {
+                    "review_body": "I did not liked the article",
+                    "rating_value": 3
+                }
+            },
             format="json")
         self.assertEqual(edit_response.status_code, status.HTTP_403_FORBIDDEN)

--- a/authors/apps/articles/tests/test_social_share.py
+++ b/authors/apps/articles/tests/test_social_share.py
@@ -8,16 +8,10 @@ from authors.apps.articles.models import Article
 class TestArticle(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "Test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email='test@mail.com',
+            username='Test',
+            password='test1234'
         )
 
         # verify email

--- a/authors/apps/authentication/tests/test_email.py
+++ b/authors/apps/authentication/tests/test_email.py
@@ -33,18 +33,24 @@ class EmailTest(TestCase):
         self.assertFalse(test_user.is_verified)
 
     def test_email_sent(self):
-        response = send_verification_email('authorshaven23@gmail.com',
-          'yt@yopmail.com',
-          'Please verify mail', '<p>hello sir<p>')
+        response = send_verification_email(
+            'authorshaven23@gmail.com',
+            'yt@yopmail.com',
+            'Please verify mail', '<p>hello sir<p>'
+        )
         self.assertTrue(response.status_code == 202)
 
     def test_error_email_not_sent(self):
-        response = send_verification_email('authorshaven23@gmail.com', 
-        'to', '', '<p>outhors</p>')
+        response = send_verification_email(
+            'authorshaven23@gmail.com',
+            'to', '', '<p>outhors</p>')
         self.assertFalse(response)
 
     def test_verification_success_if_user_passes_valid_token(self):
-        """Users should be able to verify their account if they pass a valid token"""
+        """
+        Users should be able to verify their account if they
+        pass a valid token
+        """
 
         self.client.post(
             reverse('authentication:user-signup'),

--- a/authors/apps/authentication/tests/test_password_reset.py
+++ b/authors/apps/authentication/tests/test_password_reset.py
@@ -5,6 +5,7 @@ from rest_framework import test, status
 from ..models import User, ResetPasswordToken
 from ..jwt_generator import jwt_encode
 
+
 class TestPasswordResetRequest(TestCase):
     """
     tests password reset functionality
@@ -33,7 +34,7 @@ class TestPasswordResetRequest(TestCase):
 
     def test_non_existent_user(self):
         """
-        tests that an invalid user cannot send password reset request 
+        tests that an invalid user cannot send password reset request
         """
         non_existent_email = {"email": "test@gmail.com"}
         response = self.client.post(
@@ -42,12 +43,14 @@ class TestPasswordResetRequest(TestCase):
             format='json'
         )
         returned_data = json.loads(response.content)
-        self.assertIn('User with that email does not exist', str(returned_data))
+        self.assertIn(
+            'User with that email does not exist', str(returned_data)
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_invalid_email(self):
         """
-        tests that an invalid email address pattern cannot send request 
+        tests that an invalid email address pattern cannot send request
         """
         invalid_email = {"email": "testgmail.com"}
         response = self.client.post(
@@ -61,7 +64,7 @@ class TestPasswordResetRequest(TestCase):
 
     def test_empty_email_string(self):
         """
-        tests that an empty string doesn't pass into the server 
+        tests that an empty string doesn't pass into the server
         """
         empty_email = {"email": ""}
         response = self.client.post(
@@ -95,8 +98,10 @@ class TestPasswordResetRequest(TestCase):
         user = User.objects.get(email=self.user.email)
         token = jwt_encode(user_id=user.pk, days=10)
         response = self.client.put(
-            reverse('authentication:set-updated-password',
-            kwargs={'reset_token': token}),
+            reverse(
+                'authentication:set-updated-password',
+                kwargs={'reset_token': token}
+            ),
             password,
             format='json'
         )

--- a/authors/apps/authentication/tests/test_user_details.py
+++ b/authors/apps/authentication/tests/test_user_details.py
@@ -7,18 +7,13 @@ from authors.apps.authentication.models import User
 class TestUser(TestCase):
     def setUp(self):
         self.client = test.APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "user@mail.com",
-                    "username": "user",
-                    "password": "user1234"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email="user@mail.com",
+            username="user",
+            password="user1234"
         )
-        #verify the user
+
+        # verify the user
         test_user = User.objects.get(username='user')
         test_user.is_verified = True
         test_user.save()

--- a/authors/apps/bookmark/tests.py
+++ b/authors/apps/bookmark/tests.py
@@ -16,16 +16,10 @@ class TestCreateBookmark(TestCase):
     def setUp(self):
         """Create, authenticate and login a first user."""
         self.client_1 = APIClient()
-        self.user_1 = self.client_1.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user_1 = User.objects.create_user(
+            email="demo@mail.com",
+            username="Bob",
+            password="Bob12345"
         )
         test_user_1 = User.objects.get(username='Bob')
         test_user_1.is_verified = True
@@ -45,16 +39,10 @@ class TestCreateBookmark(TestCase):
 
         """Create, authenticate and login a second user."""
         self.client_2 = APIClient()
-        self.user_2 = self.client_2.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "mail@demo.com",
-                    "username": "Mary",
-                    "password": "abc123ok"
-                }
-            },
-            format="json"
+        self.user_2 = User.objects.create_user(
+            email="mail@demo.com",
+            username="Mary",
+            password="abc123ok"
         )
         test_user_2 = User.objects.get(username='Mary')
         test_user_2.is_verified = True
@@ -128,16 +116,10 @@ class TestRetrieveBookmarks(TestCase):
     the view that retrieves user bookmarks."""
     def setUp(self):
         self.client_1 = APIClient()
-        self.user_1 = self.client_1.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user_1 = User.objects.create_user(
+            email="demo@mail.com",
+            username="Bob",
+            password="Bob12345"
         )
         test_user_1 = User.objects.get(username='Bob')
         test_user_1.is_verified = True
@@ -230,16 +212,10 @@ class TestRetrieveArticle(TestCase):
 
     def setUp(self):
         self.client_1 = APIClient()
-        self.user_1 = self.client_1.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user_1 = User.objects.create_user(
+            email="demo@mail.com",
+            username="Bob",
+            password="Bob12345"
         )
         test_user_1 = User.objects.get(username='Bob')
         test_user_1.is_verified = True

--- a/authors/apps/comments/tests/test_like_comment.py
+++ b/authors/apps/comments/tests/test_like_comment.py
@@ -18,8 +18,10 @@ class TestLikeComment(TestCase):
         Set up reusable parts of the test class
         """
         self.client = test.APIClient()
-        self.user = User.objects.create_user('disliker', 'tworivers@gmail.com',
-                                             "usergeneration0")
+        self.user = User.objects.create_user(
+            'disliker', 'tworivers@gmail.com',
+            "usergeneration0"
+        )
 
         self.user.is_verified = True
         self.user.save()
@@ -251,7 +253,10 @@ class TestLikeComment(TestCase):
             format='json'
         )
         output = json.loads(response.content)
-        self.assertEqual(output['response'], "User has already liked/disliked this comment.")
+        self.assertEqual(
+            output['response'],
+            "User has already liked/disliked this comment."
+        )
         self.assertEqual(output['hasRated'], True)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -277,6 +282,9 @@ class TestLikeComment(TestCase):
             format='json'
         )
         output = json.loads(response.content)
-        self.assertEqual(output['response'], "User has not liked/disliked this comment, or this comment does not exist.")
+        self.assertEqual(
+            output['response'],
+            "User has not liked/disliked this comment, or this comment does not exist."
+        )
         self.assertEqual(output['hasRated'], False)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/comments/tests/test_validation.py
+++ b/authors/apps/comments/tests/test_validation.py
@@ -10,19 +10,13 @@ class TestValidation(TestCase):
     def setUp(self):
         # User 1
         self.client = test.APIClient()
-        self.user_signup = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test@mail.com",
-                    "username": "test",
-                    "password": "test1234"
-                }
-            },
-            format="json"
+        self.user_signup = User.objects.create_user(
+            email="test@mail.com",
+            username="test",
+            password="test1234"
         )
         self.user = User.objects.get(
-            email=self.user_signup.data.get('email')
+            email=self.user_signup.email
         )
         self.user.is_verified = True
         self.user.save()
@@ -47,19 +41,13 @@ class TestValidation(TestCase):
 
         # User 2
         self.client2 = test.APIClient()
-        self.user_signup2 = self.client2.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "test2@mail.com",
-                    "username": "test2",
-                    "password": "test21234"
-                }
-            },
-            format="json"
+        self.user_signup2 = User.objects.create_user(
+            email="test2@mail.com",
+            username="test2",
+            password="test21234"
         )
         self.user2 = User.objects.get(
-            email=self.user_signup2.data.get('email')
+            email=self.user_signup2.email
         )
         self.user2.is_verified = True
         self.user2.save()

--- a/authors/apps/follow/tests.py
+++ b/authors/apps/follow/tests.py
@@ -19,16 +19,10 @@ class TestFollowViews(TestCase):
         """Create, authenticate and login first user. Also creates
         a profile."""
         self.client_1 = APIClient()
-        self.user_1 = self.client_1.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user_1 = User.objects.create_user(
+            email="demo@mail.com",
+            username="Bob",
+            password="Bob12345"
         )
         test_user_1 = User.objects.get(username='Bob')
         test_user_1.is_verified = True
@@ -52,19 +46,13 @@ class TestFollowViews(TestCase):
                                    "total_article": 0
                                }
                                }
-        
+
         """Create, authenticate and login second user"""
         self.client_2 = APIClient()
-        self.user_2 = self.client_2.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "mail@demo.com",
-                    "username": "Mary",
-                    "password": "Mary12345"
-                }
-            },
-            format="json"
+        self.user_2 = User.objects.create_user(
+            email="mail@demo.com",
+            username="Mary",
+            password="Mary12345"
         )
         test_user_2 = User.objects.get(username='Mary')
         test_user_2.is_verified = True
@@ -111,13 +99,16 @@ class TestFollowViews(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_check_to_verify_whether_user_has_followed_another_user(self):
-        initial_follow = self.client_1.post(reverse('follow:follow-user',
-                                      args=['Mary']), format="json")
+        initial_follow = self.client_1.post(reverse(
+            'follow:follow-user',
+            args=['Mary']),
+            format="json"
+        )
         response = self.client_1.post(reverse('follow:check-follow',
                                       args=['Mary']), format="json")
         self.assertEqual(response.data['success'], True)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-    
+
     def test_check_to_verify_whether_user_has_not_followed_another_user(self):
         response = self.client_1.post(reverse('follow:check-follow',
                                       args=['Mary']), format="json")

--- a/authors/apps/profiles/tests/test_profiles.py
+++ b/authors/apps/profiles/tests/test_profiles.py
@@ -49,16 +49,10 @@ class TestModelCase(TestCase):
         the second being invalid."""
         self.test_client = APIClient()
         self.client = APIClient()
-        self.user = self.client.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user = User.objects.create_user(
+            email="demo@mail.com",
+            username="Bob",
+            password="Bob12345"
         )
         # Verify email
         test_user = User.objects.get(username='Bob')

--- a/authors/apps/report/tests.py
+++ b/authors/apps/report/tests.py
@@ -21,16 +21,10 @@ class TestReportViews(TestCase):
         Create, authenticate and login first user.
         """
         self.client_1 = APIClient()
-        self.user_1 = self.client_1.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "demo@mail.com",
-                    "username": "Bob",
-                    "password": "Bob12345"
-                }
-            },
-            format="json"
+        self.user_1 = User.objects.create_user(
+            email="demo@mail.com",
+            username="Bob",
+            password="Bob12345"
         )
         test_user_1 = User.objects.get(username='Bob')
         test_user_1.is_verified = True
@@ -50,16 +44,10 @@ class TestReportViews(TestCase):
         Create, authenticate and login a second user.
         """
         self.client_2 = APIClient()
-        self.user_2 = self.client_2.post(
-            reverse('authentication:user-signup'),
-            data={
-                "user": {
-                    "email": "mail@demo.com",
-                    "username": "Mary",
-                    "password": "Mary12345"
-                }
-            },
-            format="json"
+        self.user_2 = User.objects.create_user(
+            email="mail@demo.com",
+            username="Mary",
+            password="Mary12345"
         )
         test_user_2 = User.objects.get(username='Mary')
         test_user_2.is_verified = True


### PR DESCRIPTION
#### What does this PR do?
Removes calls to the signup endpoint in all the tests

#### Description of the task to be completed
Create a user directly by invoking the user object creation method

#### How should this be manually tested?
- Setup the following environmental variables in a .env file
```
DATABASE_URL=<database_url>
export DJANGO_SETTINGS_MODULE=authors.settings
export SECRET_KEY=<>
export FROM_EMAIL=<valid email>
export URL=<localhost>
export AH_HOST=<localhost>
export DOMAIN=<localhost>
```
- Clone the repo and navigate to the root directory
- Create a virtual environment by typing `virtualenv venv` and activate it
- Install requirements by typing `pip install -r dev-requirements.txt`
- Setup a database and define the `DATABASE_URL` in a `.env` file. Export the configuration variable
- Run the tests by typing `python manage.py test`

#### Relevant PT stories
https://www.pivotaltracker.com/story/show/166207237